### PR TITLE
Overall corrections for filter spectra bounds

### DIFF
--- a/LUCI/LuciFit.py
+++ b/LUCI/LuciFit.py
@@ -223,14 +223,14 @@ class Fit:
         # Determine filter
         global bound_lower, bound_upper
         if self.filter == 'SN3':
-            bound_lower = 14300  # 16000
-            bound_upper = 14500  # 16400
+            bound_lower = 14500  # 16000
+            bound_upper = 14600  # 16400
         elif self.filter == 'SN2':
-            bound_lower = 18600
-            bound_upper = 19000
+            bound_lower = 19000
+            bound_upper = 19500
         elif self.filter == 'SN1':
-            bound_lower = 25300
-            bound_upper = 25700
+            bound_lower = 25700
+            bound_upper = 26300
         elif self.filter == 'C3' and 'OII3726' in self.lines:
             ## This is true for objects at redshift ~0.465
             # In this case we pretend we are in SN1

--- a/LUCI/LuciUtility.py
+++ b/LUCI/LuciUtility.py
@@ -211,8 +211,8 @@ def read_in_reference_spectrum(ref_spec, hdr_dict):
         min_ = np.argmin(np.abs(np.array(channel) - 19000))
         max_ = np.argmin(np.abs(np.array(channel) - 21000))
     elif hdr_dict['FILTER'] == 'SN1':
-        min_ = np.argmin(np.abs(np.array(channel) - 25500))
-        max_ = np.argmin(np.abs(np.array(channel) - 27500))
+        min_ = np.argmin(np.abs(np.array(channel) - 25700))
+        max_ = np.argmin(np.abs(np.array(channel) - 27700))
     elif hdr_dict['FILTER'] == 'C3':
         min_ = np.argmin(np.abs(np.array(channel) - 17500))
         max_ = np.argmin(np.abs(np.array(channel) - 19500))

--- a/LuciBase.py
+++ b/LuciBase.py
@@ -902,18 +902,18 @@ class Luci():
         if self.hdr_dict['FILTER'] == 'SN3':
             flux_min = 15150;
             flux_max = 15300;
-            noise_min = 14250;
-            noise_max = 14400
+            noise_min = 14500;
+            noise_max = 14600
         elif self.hdr_dict['FILTER'] == 'SN2':
-            flux_min = 19500;
+            flux_min = 19800;
             flux_max = 20750;
-            noise_min = 18600;
-            noise_max = 19000
+            noise_min = 19000;
+            noise_max = 19500
         elif self.hdr_dict['FILTER'] == 'SN1':
             flux_min = 26550;
             flux_max = 27550;
-            noise_min = 25300;
-            noise_max = 25700
+            noise_min = 25700;
+            noise_max = 26300
         else:
             print('SNR Calculation for this filter has not been implemented')
 


### PR DESCRIPTION
Some of the wavenumber bounds chosen for SITELLE's filters were not optimal and sometimes outside of the spectra. These corrections solve this issue which was causing problems for LUCI's fitting functions when encountering spectra in the SN1 and SN2 filters.